### PR TITLE
Allow comparing error codes to nil

### DIFF
--- a/lib/windows_error/error_code.rb
+++ b/lib/windows_error/error_code.rb
@@ -39,6 +39,8 @@ module WindowsError
         self.value == other_object.value
       elsif other_object.kind_of? Integer
         self.value == other_object
+      elsif other_object.nil?
+        false
       else
         raise ArgumentError, "Cannot compare a #{self.class} to a #{other_object.class}"
       end


### PR DESCRIPTION
This allows `WindowsError::ErrorCode` instances to be compared to `nil`. Without this change, the `ArgumentError` will be raised.

Testing:
```
>> WindowsError::NTStatus::STATUS_SUCCESS == nil
=> false
```

Without these changes, the following exception would be raised:
```
[3] pry(main)> WindowsError::NTStatus::STATUS_SUCCESS == nil
ArgumentError: Cannot compare a WindowsError::ErrorCode to a NilClass
from /home/smcintyre/Repositories/windows_error/lib/windows_error/error_code.rb:43:in `=='
```

These changes notably make this type compatible with use in [BinData](https://github.com/zeroSteiner/ruby_smb/commit/1a8276d88ca70d7e4436baf27d13c8f3cc5c7bb5) which will check if values are nil.