### PR TITLE
Sort constants so the order is deterministic

### DIFF
--- a/lib/windows_error/nt_status.rb
+++ b/lib/windows_error/nt_status.rb
@@ -14,7 +14,7 @@ module WindowsError
     def self.find_by_retval(retval)
       raise ArgumentError, "Invalid Return Code!" unless retval.kind_of? Integer
       error_codes = []
-      self.constants.each do |constant_name|
+      self.constants.sort.each do |constant_name|
         error_code = self.const_get(constant_name)
         if error_code == retval
           error_codes << error_code

--- a/lib/windows_error/win32.rb
+++ b/lib/windows_error/win32.rb
@@ -14,7 +14,7 @@ module WindowsError
     def self.find_by_retval(retval)
       raise ArgumentError, "Invalid Return Code!" unless retval.kind_of? Integer
       error_codes = []
-      self.constants.each do |constant_name|
+      self.constants.sort.each do |constant_name|
         error_code = self.const_get(constant_name)
         if error_code == retval
           error_codes << error_code


### PR DESCRIPTION
This will ensure that the order of the return values is always the same. As a byproduct of this the NTStatus `ERROR_SUCCESS` will always be the first when 0 is looked up because it comes before `ERROR_WAIT_0` when sorted alphabetically.

# Testing

```
[1] pry(main)> require 'windows_error'
=> true
[2] pry(main)> require 'windows_error/nt_status'
=> true
[3] pry(main)> 10.times { puts WindowsError::NTStatus.find_by_retval(0).first }
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
(0x00000000) STATUS_SUCCESS: The operation completed successfully.
=> 10
```