### PR TITLE
Add missing require statements

### DIFF
--- a/lib/windows_error.rb
+++ b/lib/windows_error.rb
@@ -1,4 +1,8 @@
-require 'windows_error/version'
 require 'windows_error/error_code'
+require 'windows_error/win32'
+require 'windows_error/nt_status'
+require 'windows_error/h_result'
+require 'windows_error/version'
+
 module WindowsError
 end


### PR DESCRIPTION
This adds missing require statements so once the `WindowsError` module is loaded, the Win32, NTStatus and HResult modules are all accessible without needing to be required individually.

Trying to fix instances like this in Metasploit Framework where `WindowsError` is loaded but the others are not.

```
[-] 192.168.159.10:445 - Auxiliary failed: NameError uninitialized constant WindowsError::HResult
[-] 192.168.159.10:445 - Call stack:
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:187:in `do_request_cert'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:100:in `request_certificate'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:68:in `block in action_request_cert'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:83:in `with_ipc_tree'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:67:in `action_request_cert'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:53:in `run'
```